### PR TITLE
Refactor SkinViewer

### DIFF
--- a/.eslintrc.yaml
+++ b/.eslintrc.yaml
@@ -9,3 +9,4 @@ extends:
 rules:
   '@typescript-eslint/no-inferrable-types': off
   '@typescript-eslint/interface-name-prefix': off
+  '@typescript-eslint/no-empty-interface': off

--- a/README.md
+++ b/README.md
@@ -20,18 +20,25 @@ Three.js powered Minecraft skin viewer.
 ```html
 <div id="skin_container"></div>
 <script>
-	let skinViewer = new skinview3d.SkinViewer(document.getElementById("skin_container"));
+	let skinViewer = new skinview3d.SkinViewer({
+		domElement: document.getElementById("skin_container"),
+		width: 300,
+		height: 400,
+		skin: "img/skin.png"
+	});
 
-	// Set viewer size
-	skinViewer.width = 300;
-	skinViewer.height = 400;
+	// Change viewer size
+	skinViewer.width = 600;
+	skinViewer.height = 800;
 
-	// Load skin & cape
-	skinViewer.loadSkinFrom("img/skin.png");
-	skinViewer.loadCapeFrom("img/cape.png");
+	// Load another skin
+	skinViewer.loadSkin("img/skin2.png");
 
-	// Hide the cape
-	skinViewer.playerObject.cape.visible = false;
+	// Load a cape
+	skinViewer.loadCape("img/cape.png");
+
+	// Unload(hide) the cape
+	skinViewer.loadCape(null);
 
 	// Control objects with your mouse!
 	let control = skinview3d.createOrbitControls(skinViewer);

--- a/README.md
+++ b/README.md
@@ -20,21 +20,18 @@ Three.js powered Minecraft skin viewer.
 ```html
 <div id="skin_container"></div>
 <script>
-	let skinViewer = new skinview3d.SkinViewer({
-		domElement: document.getElementById("skin_container"),
-		width: 600,
-		height: 600,
-		skinUrl: "img/skin.png",
-		capeUrl: "img/cape.png"
-	});
+	let skinViewer = new skinview3d.SkinViewer(document.getElementById("skin_container"));
 
-	// Change the textures
-	skinViewer.skinUrl = "img/skin2.png";
-	skinViewer.capeUrl = "img/cape2.png";
-
-	// Resize the skin viewer
+	// Set viewer size
 	skinViewer.width = 300;
 	skinViewer.height = 400;
+
+	// Load skin & cape
+	skinViewer.loadSkinFrom("img/skin.png");
+	skinViewer.loadCapeFrom("img/cape.png");
+
+	// Hide the cape
+	skinViewer.playerObject.cape.visible = false;
 
 	// Control objects with your mouse!
 	let control = skinview3d.createOrbitControls(skinViewer);

--- a/README.md
+++ b/README.md
@@ -20,8 +20,7 @@ Three.js powered Minecraft skin viewer.
 ```html
 <div id="skin_container"></div>
 <script>
-	let skinViewer = new skinview3d.SkinViewer({
-		domElement: document.getElementById("skin_container"),
+	let skinViewer = new skinview3d.SkinViewer(document.getElementById("skin_container"), {
 		width: 300,
 		height: 400,
 		skin: "img/skin.png"

--- a/examples/index.html
+++ b/examples/index.html
@@ -22,12 +22,11 @@
 	<script type="text/javascript" src="../bundles/skinview3d.bundle.js"></script>
 
 	<script>
-		let skinViewer = new skinview3d.SkinViewer({
-			domElement: document.getElementById("skin_container"),
-			width: 900,
-			height: 900,
-			skinUrl: "./1_8_texturemap_redux.png"
-		});
+		let skinViewer = new skinview3d.SkinViewer(document.getElementById("skin_container"));
+		skinViewer.width = 400;
+		skinViewer.height = 300;
+
+		skinViewer.loadSkinFrom("./1_8_texturemap_redux.png");
 
 		// By default, the skin model is automatically detected. You can turn it off in this way:
 		// skinViewer.detectModel = false;

--- a/examples/index.html
+++ b/examples/index.html
@@ -22,8 +22,7 @@
 	<script type="text/javascript" src="../bundles/skinview3d.bundle.js"></script>
 
 	<script>
-		let skinViewer = new skinview3d.SkinViewer({
-			domElement: document.getElementById("skin_container"),
+		let skinViewer = new skinview3d.SkinViewer(document.getElementById("skin_container"), {
 			width: 400,
 			height: 300,
 			skin: "./1_8_texturemap_redux.png"

--- a/examples/index.html
+++ b/examples/index.html
@@ -22,15 +22,12 @@
 	<script type="text/javascript" src="../bundles/skinview3d.bundle.js"></script>
 
 	<script>
-		let skinViewer = new skinview3d.SkinViewer(document.getElementById("skin_container"));
-		skinViewer.width = 400;
-		skinViewer.height = 300;
-
-		skinViewer.loadSkinFrom("./1_8_texturemap_redux.png");
-
-		// By default, the skin model is automatically detected. You can turn it off in this way:
-		// skinViewer.detectModel = false;
-		// skinViewer.playerObject.skin.slim = true;
+		let skinViewer = new skinview3d.SkinViewer({
+			domElement: document.getElementById("skin_container"),
+			width: 400,
+			height: 300,
+			skin: "./1_8_texturemap_redux.png"
+		});
 
 		let control = new skinview3d.createOrbitControls(skinViewer);
 		skinViewer.animations.add(skinview3d.WalkingAnimation);

--- a/package-lock.json
+++ b/package-lock.json
@@ -2637,9 +2637,9 @@
 			"dev": true
 		},
 		"skinview-utils": {
-			"version": "0.3.0",
-			"resolved": "https://registry.npmjs.org/skinview-utils/-/skinview-utils-0.3.0.tgz",
-			"integrity": "sha512-QolLWQoRGhqJUFN0sN/IAWQH+XhqPyd+10VdiZQZhrTqZGPNyR5Hh8RspGGzdSqThYJhm2L15+kty5DT3tGYjg=="
+			"version": "0.5.1",
+			"resolved": "https://registry.npmjs.org/skinview-utils/-/skinview-utils-0.5.1.tgz",
+			"integrity": "sha512-6HUspYq2s1cWm7ZiiyfYanGEJ8rUAHC/qChBqFD2m5WGQ4Oy2FkInSFB8u1sB0oM49cmEFye09LUwdL6ev/72Q=="
 		},
 		"slice-ansi": {
 			"version": "2.1.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -2637,9 +2637,9 @@
 			"dev": true
 		},
 		"skinview-utils": {
-			"version": "0.2.0",
-			"resolved": "https://registry.npmjs.org/skinview-utils/-/skinview-utils-0.2.0.tgz",
-			"integrity": "sha512-MRcZf/u9Ksn1VbbBzjG50XAeKLMCPpQ2Onm+31nUcOw97XtS2sVBc4nNPwNGvUL5I7QTqfyr885gMxMkfp1klQ=="
+			"version": "0.3.0",
+			"resolved": "https://registry.npmjs.org/skinview-utils/-/skinview-utils-0.3.0.tgz",
+			"integrity": "sha512-QolLWQoRGhqJUFN0sN/IAWQH+XhqPyd+10VdiZQZhrTqZGPNyR5Hh8RspGGzdSqThYJhm2L15+kty5DT3tGYjg=="
 		},
 		"slice-ansi": {
 			"version": "2.1.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -2637,9 +2637,9 @@
 			"dev": true
 		},
 		"skinview-utils": {
-			"version": "0.5.1",
-			"resolved": "https://registry.npmjs.org/skinview-utils/-/skinview-utils-0.5.1.tgz",
-			"integrity": "sha512-6HUspYq2s1cWm7ZiiyfYanGEJ8rUAHC/qChBqFD2m5WGQ4Oy2FkInSFB8u1sB0oM49cmEFye09LUwdL6ev/72Q=="
+			"version": "0.5.3",
+			"resolved": "https://registry.npmjs.org/skinview-utils/-/skinview-utils-0.5.3.tgz",
+			"integrity": "sha512-abvsUEiHjeUWGPmrTpVv4a2J6EhxTpdZAWg7kGHncKJyH91JKPqxnt8JvuehfO7d5J92pBLMiDV6F2IZaHZOdg=="
 		},
 		"slice-ansi": {
 			"version": "2.1.0",

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
 		"build": "npm run build:modules && npm run build:bundles",
 		"test:lint": "eslint --ext .ts src",
 		"test": "npm run test:lint",
-		"dev:watch:modules": "tsc -w -p .",
+		"dev:watch:modules": "tsc -w --declaration --sourceMap --outDir libs -p .",
 		"dev:watch:bundles": "rollup -w -c",
 		"dev:serve": "ws",
 		"dev": "npm-run-all --parallel dev:watch:modules dev:watch:bundles dev:serve",
@@ -38,7 +38,7 @@
 		"bundles"
 	],
 	"dependencies": {
-		"skinview-utils": "^0.3.0",
+		"skinview-utils": "^0.5.1",
 		"three": "^0.117.1"
 	},
 	"devDependencies": {

--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
 		"bundles"
 	],
 	"dependencies": {
-		"skinview-utils": "^0.2.0",
+		"skinview-utils": "^0.3.0",
 		"three": "^0.117.1"
 	},
 	"devDependencies": {

--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
 		"bundles"
 	],
 	"dependencies": {
-		"skinview-utils": "^0.5.1",
+		"skinview-utils": "^0.5.3",
 		"three": "^0.117.1"
 	},
 	"devDependencies": {

--- a/src/animation.ts
+++ b/src/animation.ts
@@ -102,7 +102,7 @@ export class CompositeAnimation implements IAnimation {
 export class RootAnimation extends CompositeAnimation implements AnimationHandle {
 	speed: number = 1.0;
 	progress: number = 0.0;
-	readonly clock: Clock = new Clock(true);
+	private readonly clock: Clock = new Clock(true);
 
 	get animation(): RootAnimation {
 		return this;

--- a/src/model.ts
+++ b/src/model.ts
@@ -1,3 +1,4 @@
+import { ModelType } from "skinview-utils";
 import { BoxGeometry, DoubleSide, FrontSide, Group, Mesh, MeshBasicMaterial, Object3D, Texture, Vector2 } from "three";
 
 function toFaceVertices(x1: number, y1: number, x2: number, y2: number, w: number, h: number): Array<Vector2> {
@@ -59,7 +60,7 @@ export class SkinObject extends Group {
 	readonly leftLeg: BodyPart;
 
 	private modelListeners: Array<() => void> = []; // called when model(slim property) is changed
-	private _slim = false;
+	private slim = false;
 
 	constructor(texture: Texture) {
 		super();
@@ -364,15 +365,15 @@ export class SkinObject extends Group {
 		this.leftLeg.position.x = 2;
 		this.add(this.leftLeg);
 
-		this.slim = false;
+		this.modelType = "default";
 	}
 
-	get slim(): boolean {
-		return this._slim;
+	get modelType(): ModelType {
+		return this.slim ? "slim" : "default";
 	}
 
-	set slim(value) {
-		this._slim = value;
+	set modelType(value: ModelType) {
+		this.slim = value === "slim";
 		this.modelListeners.forEach(listener => listener());
 	}
 

--- a/src/model.ts
+++ b/src/model.ts
@@ -19,7 +19,6 @@ function toCapeVertices(x1: number, y1: number, x2: number, y2: number): Array<V
 }
 
 function setVertices(box: BoxGeometry, top: Array<Vector2>, bottom: Array<Vector2>, left: Array<Vector2>, front: Array<Vector2>, right: Array<Vector2>, back: Array<Vector2>): void {
-
 	box.faceVertexUvs[0] = [];
 	box.faceVertexUvs[0][0] = [right[3], right[0], right[2]];
 	box.faceVertexUvs[0][1] = [right[0], right[1], right[2]];

--- a/src/viewer.ts
+++ b/src/viewer.ts
@@ -1,56 +1,44 @@
+import { applyMixins, CapeContainer, ModelType, SkinContainer } from "skinview-utils";
 import { NearestFilter, PerspectiveCamera, Scene, Texture, Vector2, WebGLRenderer } from "three";
 import { RootAnimation } from "./animation.js";
 import { PlayerObject } from "./model.js";
-import { isSlimSkin, loadCapeToCanvas, loadSkinToCanvas } from "skinview-utils";
 
-export interface SkinViewerOptions {
-	domElement: Node;
-	skinUrl?: string;
-	capeUrl?: string;
-	width?: number;
-	height?: number;
-	detectModel?: boolean;
+export type LoadOptions = {
+	makeVisible?: boolean;
+};
+
+function toMakeVisible(options?: LoadOptions): boolean {
+	if (options && options.makeVisible === false) {
+		return false;
+	}
+	return true;
 }
 
-export class SkinViewer {
+class SkinViewer {
 
-	public readonly domElement: Node;
-	public readonly animations: RootAnimation = new RootAnimation();
-	public detectModel: boolean = true;
+	readonly scene: Scene;
+	readonly camera: PerspectiveCamera;
+	readonly renderer: WebGLRenderer;
+	readonly playerObject: PlayerObject;
+	readonly animations: RootAnimation = new RootAnimation();
 
-	public readonly skinImg: HTMLImageElement;
-	public readonly skinCanvas: HTMLCanvasElement;
-	public readonly skinTexture: Texture;
-
-	public readonly capeImg: HTMLImageElement;
-	public readonly capeCanvas: HTMLCanvasElement;
-	public readonly capeTexture: Texture;
-
-	public readonly scene: Scene;
-	public readonly camera: PerspectiveCamera;
-	public readonly renderer: WebGLRenderer;
-
-	public readonly playerObject: PlayerObject;
+	protected readonly skinCanvas: HTMLCanvasElement;
+	protected readonly capeCanvas: HTMLCanvasElement;
+	private readonly skinTexture: Texture;
+	private readonly capeTexture: Texture;
 
 	private _disposed: boolean = false;
 	private _renderPaused: boolean = false;
 	private _skinSet: boolean = false;
 	private _capeSet: boolean = false;
 
-	constructor(options: SkinViewerOptions) {
-		this.domElement = options.domElement;
-		if (options.detectModel === false) {
-			this.detectModel = false;
-		}
-
+	constructor(readonly domElement: Node) {
 		// texture
-		this.skinImg = new Image();
 		this.skinCanvas = document.createElement("canvas");
 		this.skinTexture = new Texture(this.skinCanvas);
 		this.skinTexture.magFilter = NearestFilter;
 		this.skinTexture.minFilter = NearestFilter;
 
-		this.capeImg = new Image();
 		this.capeCanvas = document.createElement("canvas");
 		this.capeTexture = new Texture(this.capeCanvas);
 		this.capeTexture.magFilter = NearestFilter;
@@ -73,39 +61,22 @@ export class SkinViewer {
 		this.playerObject.cape.visible = false;
 		this.scene.add(this.playerObject);
 
-		// texture loading
-		this.skinImg.crossOrigin = "anonymous";
-		this.skinImg.onerror = (): void => console.error("Failed loading " + this.skinImg.src);
-		this.skinImg.onload = (): void => {
-			loadSkinToCanvas(this.skinCanvas, this.skinImg);
-
-			if (this.detectModel) {
-				this.playerObject.skin.slim = isSlimSkin(this.skinCanvas);
-			}
-
-			this.skinTexture.needsUpdate = true;
-			this.playerObject.skin.visible = true;
-		};
-
-		this.capeImg.crossOrigin = "anonymous";
-		this.capeImg.onerror = (): void => console.error("Failed loading " + this.capeImg.src);
-		this.capeImg.onload = (): void => {
-			loadCapeToCanvas(this.capeCanvas, this.capeImg);
-
-			this.capeTexture.needsUpdate = true;
-			this.playerObject.cape.visible = true;
-		};
-
-		if (options.skinUrl !== undefined) {
-			this.skinUrl = options.skinUrl;
-		}
-		if (options.capeUrl !== undefined) {
-			this.capeUrl = options.capeUrl;
-		}
-		this.width = options.width === undefined ? 300 : options.width;
-		this.height = options.height === undefined ? 300 : options.height;
-
 		window.requestAnimationFrame(() => this.draw());
+	}
+
+	protected skinLoaded(model: ModelType, options?: LoadOptions): void {
+		this.skinTexture.needsUpdate = true;
+		this.playerObject.skin.modelType = model;
+		if (toMakeVisible(options)) {
+			this.playerObject.skin.visible = true;
+		}
+	}
+
+	protected capeLoaded(options?: LoadOptions): void {
+		this.capeTexture.needsUpdate = true;
+		if (toMakeVisible(options)) {
+			this.playerObject.cape.visible = true;
+		}
 	}
 
 	private draw(): void {
@@ -151,34 +122,6 @@ export class SkinViewer {
 		}
 	}
 
-	get skinUrl(): string | null {
-		return this._skinSet ? this.skinImg.src : null;
-	}
-
-	set skinUrl(url: string | null) {
-		if (url === null) {
-			this._skinSet = false;
-			this.playerObject.skin.visible = false;
-		} else {
-			this._skinSet = true;
-			this.skinImg.src = url;
-		}
-	}
-
-	get capeUrl(): string | null {
-		return this._capeSet ? this.capeImg.src : null;
-	}
-
-	set capeUrl(url: string | null) {
-		if (url === null) {
-			this._capeSet = false;
-			this.playerObject.cape.visible = false;
-		} else {
-			this._capeSet = true;
-			this.capeImg.src = url;
-		}
-	}
-
 	get width(): number {
 		return this.renderer.getSize(new Vector2()).width;
 	}
@@ -195,3 +138,6 @@ export class SkinViewer {
 		this.setSize(this.width, newHeight);
 	}
 }
+interface SkinViewer extends SkinContainer<LoadOptions>, CapeContainer<LoadOptions> { }
+applyMixins(SkinViewer, [SkinContainer, CapeContainer]);
+export { SkinViewer };

--- a/src/viewer.ts
+++ b/src/viewer.ts
@@ -4,8 +4,11 @@ import { RootAnimation } from "./animation.js";
 import { PlayerObject } from "./model.js";
 
 export type LoadOptions = {
+	/**
+	 * Whether to make the object visible after the texture is loaded. (default: true)
+	 */
 	makeVisible?: boolean;
-};
+}
 
 function toMakeVisible(options?: LoadOptions): boolean {
 	if (options && options.makeVisible === false) {
@@ -15,7 +18,6 @@ function toMakeVisible(options?: LoadOptions): boolean {
 }
 
 class SkinViewer {
-
 	readonly scene: Scene;
 	readonly camera: PerspectiveCamera;
 	readonly renderer: WebGLRenderer;
@@ -29,8 +31,6 @@ class SkinViewer {
 
 	private _disposed: boolean = false;
 	private _renderPaused: boolean = false;
-	private _skinSet: boolean = false;
-	private _capeSet: boolean = false;
 
 	constructor(readonly domElement: Node) {
 		// texture
@@ -44,7 +44,6 @@ class SkinViewer {
 		this.capeTexture.magFilter = NearestFilter;
 		this.capeTexture.minFilter = NearestFilter;
 
-		// scene
 		this.scene = new Scene();
 
 		// Use smaller fov to avoid distortion

--- a/src/viewer.ts
+++ b/src/viewer.ts
@@ -11,7 +11,6 @@ export type LoadOptions = {
 }
 
 export type SkinViewerOptions = {
-	domElement: Node;
 	width?: number;
 	height?: number;
 	skin?: RemoteImage | TextureSource;
@@ -41,15 +40,8 @@ class SkinViewer {
 	private _disposed: boolean = false;
 	private _renderPaused: boolean = false;
 
-	constructor(domElement: Node);
-	constructor(options: SkinViewerOptions);
-
-	constructor(param: Node | SkinViewerOptions) {
-		if (param instanceof Node) {
-			this.domElement = param;
-		} else {
-			this.domElement = param.domElement;
-		}
+	constructor(domElement: Node, options: SkinViewerOptions = {}) {
+		this.domElement = domElement;
 
 		// texture
 		this.skinCanvas = document.createElement("canvas");
@@ -80,27 +72,25 @@ class SkinViewer {
 
 		window.requestAnimationFrame(() => this.draw());
 
-		if (!(param instanceof Node)) {
-			if (param.skin !== undefined) {
-				if (isTextureSource(param.skin)) {
-					this.loadSkin(param.skin);
-				} else {
-					this.loadSkin(param.skin);
-				}
+		if (options.skin !== undefined) {
+			if (isTextureSource(options.skin)) {
+				this.loadSkin(options.skin);
+			} else {
+				this.loadSkin(options.skin);
 			}
-			if (param.cape !== undefined) {
-				if (isTextureSource(param.cape)) {
-					this.loadCape(param.cape);
-				} else {
-					this.loadCape(param.cape);
-				}
+		}
+		if (options.cape !== undefined) {
+			if (isTextureSource(options.cape)) {
+				this.loadCape(options.cape);
+			} else {
+				this.loadCape(options.cape);
 			}
-			if (param.width !== undefined) {
-				this.width = param.width;
-			}
-			if (param.height !== undefined) {
-				this.height = param.height;
-			}
+		}
+		if (options.width !== undefined) {
+			this.width = options.width;
+		}
+		if (options.height !== undefined) {
+			this.height = options.height;
 		}
 	}
 

--- a/src/viewer.ts
+++ b/src/viewer.ts
@@ -1,4 +1,4 @@
-import { applyMixins, CapeContainer, ModelType, SkinContainer, RemoteImage, TextureSource, isTextureSource } from "skinview-utils";
+import { applyMixins, CapeContainer, ModelType, SkinContainer, RemoteImage, TextureSource } from "skinview-utils";
 import { NearestFilter, PerspectiveCamera, Scene, Texture, Vector2, WebGLRenderer } from "three";
 import { RootAnimation } from "./animation.js";
 import { PlayerObject } from "./model.js";
@@ -73,18 +73,10 @@ class SkinViewer {
 		window.requestAnimationFrame(() => this.draw());
 
 		if (options.skin !== undefined) {
-			if (isTextureSource(options.skin)) {
-				this.loadSkin(options.skin);
-			} else {
-				this.loadSkin(options.skin);
-			}
+			this.loadSkin(options.skin);
 		}
 		if (options.cape !== undefined) {
-			if (isTextureSource(options.cape)) {
-				this.loadCape(options.cape);
-			} else {
-				this.loadCape(options.cape);
-			}
+			this.loadCape(options.cape);
 		}
 		if (options.width !== undefined) {
 			this.width = options.width;

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -2,11 +2,10 @@
 	"compilerOptions": {
 		"module": "es2015",
 		"moduleResolution": "node",
+		"target": "es2017",
 		"lib": [
-			"dom",
-			"es2015"
+			"dom"
 		],
-		"target": "es2015",
 		"strict": true
 	},
 	"include": [


### PR DESCRIPTION
This refactor was previously discussed in https://github.com/bs-community/skinview-utils/issues/3. So far I've nearly finished it, and I'm submitting it here for reviewing. This PR is a draft because there are still something that needs to be discussed. (see "Concerns" below)

Major changes:
 * **SkinObject**: `slim` is replaced by `modelType`, which can be either "default" or "slim".
 * **SkinViewer**: `skinUrl`/`capeUrl` are replaced by [`loadSkin`]/[`loadCape`].
     * If `null` is passed in, skin/cape will be hidden.
     * If a **[TextureSource]** (can be [HTMLCanvasElement], [OffscreenCanvas], [HTMLImageElement], [HTMLVideoElement] or [ImageBitmap]) is passed in, texture loading will **complete immediately**.
    * If a **URL string** or a **[RemoteImage]** object is passed in, texture loading will be done **asynchronously**.  A [Promise] representing the result is returned.
    * By default, skin (or cape) is made visible when texture loading completes. This behavior can be overridden by setting the [`makeVisible`] property in the `options` argument.
    * `detectModel` option is removed. To forcibly specify the model, set the `model` argument when invoking [`loadSkin`].

Concerns:
 * ~~The constructor of SkinViewer no longer receives "object argument", therefore you have to specify other properties (such as width and height) in a new statement.~~
    * ~~It was mentioned a long time ago: https://github.com/bs-community/skinview3d/pull/31#issuecomment-413524854.~~
    * ~~Alternatively, we can choose to preserve the "object argument" constructor. But due to the changes made in the refactor, it has to be "enhanced".~~
    * _**The constructor now accepts both Node and "object argument".**_
 * ~~In order to "unload" the cape, you have to set `SkinViewer.playerObject.cape.visible` to false.~~
    * ~~This is related to the ["setting capeUrl to null" issue](https://github.com/bs-community/skinview3d/issues/48).~~
    * ~~I admit it's a bit inconvenient. Should we add something like `unloadCape`?~~
    * _**Use `loadSkin(null)` or `loadCape(null)` to unload the skin/cape.**_
 * ~~What about renaming `loadSkinFrom`/`loadCapeFrom` to `loadSkin`/`loadCape`? In this case,  `loadSkin`/`loadCape` will be overloaded.~~
    * ~~Less methods should make it more easier to understand.~~
    * ~~A rough implementation: https://github.com/bs-community/skinview-utils/commit/24708ac54a9e7c562f40e60ac1f98f4919dd748f.~~
    * _**`loadSkin`/`loadCape` now each has 3 overloads.**_

Let me know if you have any questions or comments.

[TextureSource]: https://github.com/bs-community/skinview-utils/blob/v0.5.1/src/types.ts#L2
[HTMLCanvasElement]: https://developer.mozilla.org/en-US/docs/Web/API/HTMLCanvasElement
[OffscreenCanvas]: https://developer.mozilla.org/en-US/docs/Web/API/OffscreenCanvas
[HTMLImageElement]: https://developer.mozilla.org/en-US/docs/Web/API/HTMLImageElement
[HTMLVideoElement]: https://developer.mozilla.org/en-US/docs/Web/API/HTMLVideoElement
[ImageBitmap]: https://developer.mozilla.org/en-US/docs/Web/API/ImageBitmap
[RemoteImage]: https://github.com/bs-community/skinview-utils/blob/v0.5.1/src/load-image.ts#L1-L5
[Promise]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise
[`loadSkin`]: https://github.com/bs-community/skinview-utils/blob/v0.5.1/src/viewer-mixins.ts#L24-L26
[`loadCape`]: https://github.com/bs-community/skinview-utils/blob/v0.5.1/src/viewer-mixins.ts#L46-L48
[`makeVisible`]: https://github.com/bs-community/skinview3d/blob/d86dda16bc4fa8764abbb7379f3d208c82a7c342/src/viewer.ts#L7-L10
