### PR TITLE
add 'preserveDrawingBuffer' option

### DIFF
--- a/src/viewer.ts
+++ b/src/viewer.ts
@@ -27,6 +27,11 @@ export type SkinViewerOptions = {
 	 * A new canvas is created if this parameter is unspecified.
 	 */
 	canvas?: HTMLCanvasElement;
+
+	/**
+	 * Whether to preserve the buffers until manually cleared or overwritten. Default is false.
+	 */
+	preserveDrawingBuffer?: boolean;
 }
 
 function toMakeVisible(options?: LoadOptions): boolean {
@@ -75,8 +80,9 @@ class SkinViewer {
 
 		this.renderer = new WebGLRenderer({
 			canvas: this.canvas,
-			alpha: options.alpha !== false, // alpha is on by default
-			preserveDrawingBuffer: true
+			alpha: options.alpha !== false, // default: true
+			preserveDrawingBuffer: options.preserveDrawingBuffer === true // default: false
+
 		});
 		this.renderer.setPixelRatio(window.devicePixelRatio);
 


### PR DESCRIPTION
`preserveDrawingBuffer: true` has an impact on performance, so I would like to turn it off by default.
It can still be enabled by specifying `preserveDrawingBuffer: true` in `SkinViewerOptions`.

Related: #65, #67