### PR TITLE
Swap textures

### DIFF
--- a/src/model.ts
+++ b/src/model.ts
@@ -402,8 +402,8 @@ export class CapeObject extends Group {
 		// front = inside
 		const capeBox = new BoxGeometry(10, 16, 1);
 		setVertices(capeBox,
-			toCapeVertices(1, 0, 11, 1),
-			toCapeVertices(11, 0, 21, 1),
+			toCapeVertices(11, 1, 1, 0),
+			toCapeVertices(21, 1, 11, 0),
 			toCapeVertices(11, 1, 12, 17),
 			toCapeVertices(12, 1, 22, 17),
 			toCapeVertices(0, 1, 1, 17),


### PR DESCRIPTION
The tops/bottoms of capes are the wrong way round

![image](https://user-images.githubusercontent.com/20372645/92818701-e7b62b00-f3bf-11ea-99df-4fb94055d2a4.png)
![image](https://user-images.githubusercontent.com/20372645/92819873-2d272800-f3c1-11ea-8851-5072e823c0fd.png)


You can see the blue part shows on the left rather than the right. It's the same for the bottom. This PR fixes it.