### PR TITLE
Update threejs to latest

### DIFF
--- a/examples/index.html
+++ b/examples/index.html
@@ -129,7 +129,7 @@
 
 		<div class="control-section">
 			<h1>Light</h1>
-			<label class="control">Global: <input id="global_light" type="number" value="0.40" step="0.01" min="0.00" max="2.00" size="4"></label>
+			<label class="control">Global: <input id="global_light" type="number" value="3" step="0.01" min="0.00" max="2.00" size="4"></label>
 			<label class="control">Camera: <input id="camera_light" type="number" value="0.60" step="0.01" min="0.00" max="2.00" size="4"></label>
 		</div>
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,20 +1,19 @@
 {
 	"name": "skinview3d",
-	"version": "3.0.0",
+	"version": "3.0.1",
 	"lockfileVersion": 2,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "skinview3d",
-			"version": "3.0.0",
+			"version": "3.0.1",
 			"license": "MIT",
 			"dependencies": {
 				"@types/three": "^0.142.0",
 				"skinview-utils": "^0.7.1",
-				"three": "^0.142.0"
+				"three": "^0.156.1"
 			},
 			"devDependencies": {
-				"@gplane/tsconfig": "^6.0.0",
 				"@rollup/plugin-node-resolve": "^15.0.2",
 				"@swc/core": "^1.3.53",
 				"@typescript-eslint/eslint-plugin": "^5.59.0",
@@ -104,12 +103,6 @@
 			"version": "1.3.0",
 			"resolved": "https://registry.npmjs.org/@fastify/deepmerge/-/deepmerge-1.3.0.tgz",
 			"integrity": "sha512-J8TOSBq3SoZbDhM9+R/u77hP93gz/rajSA+K2kGyijPpORPWUXHUpTaleoj+92As0S9uPRP7Oi8IqMf0u+ro6A==",
-			"dev": true
-		},
-		"node_modules/@gplane/tsconfig": {
-			"version": "6.0.0",
-			"resolved": "https://registry.npmjs.org/@gplane/tsconfig/-/tsconfig-6.0.0.tgz",
-			"integrity": "sha512-K61z8tl3I5tR66MJoGoBCY1y950fybDfPol7uzcg/YPilretE0bl41GOOX0BpRbblYLOWzSJvdqlimzjAfryog==",
 			"dev": true
 		},
 		"node_modules/@humanwhocodes/config-array": {
@@ -4291,9 +4284,9 @@
 			}
 		},
 		"node_modules/three": {
-			"version": "0.142.0",
-			"resolved": "https://registry.npmjs.org/three/-/three-0.142.0.tgz",
-			"integrity": "sha512-ESjPO+3geFr+ZUfVMpMnF/eVU2uJPOh0e2ZpMFqjNca1wApS9lJb7E4MjwGIczgt9iuKd8PEm6Pfgp2bJ92Xtg=="
+			"version": "0.156.1",
+			"resolved": "https://registry.npmjs.org/three/-/three-0.156.1.tgz",
+			"integrity": "sha512-kP7H0FK9d/k6t/XvQ9FO6i+QrePoDcNhwl0I02+wmUJRNSLCUIDMcfObnzQvxb37/0Uc9TDT0T1HgsRRrO6SYQ=="
 		},
 		"node_modules/through": {
 			"version": "2.3.8",
@@ -4645,12 +4638,6 @@
 			"version": "1.3.0",
 			"resolved": "https://registry.npmjs.org/@fastify/deepmerge/-/deepmerge-1.3.0.tgz",
 			"integrity": "sha512-J8TOSBq3SoZbDhM9+R/u77hP93gz/rajSA+K2kGyijPpORPWUXHUpTaleoj+92As0S9uPRP7Oi8IqMf0u+ro6A==",
-			"dev": true
-		},
-		"@gplane/tsconfig": {
-			"version": "6.0.0",
-			"resolved": "https://registry.npmjs.org/@gplane/tsconfig/-/tsconfig-6.0.0.tgz",
-			"integrity": "sha512-K61z8tl3I5tR66MJoGoBCY1y950fybDfPol7uzcg/YPilretE0bl41GOOX0BpRbblYLOWzSJvdqlimzjAfryog==",
 			"dev": true
 		},
 		"@humanwhocodes/config-array": {
@@ -7757,9 +7744,9 @@
 			}
 		},
 		"three": {
-			"version": "0.142.0",
-			"resolved": "https://registry.npmjs.org/three/-/three-0.142.0.tgz",
-			"integrity": "sha512-ESjPO+3geFr+ZUfVMpMnF/eVU2uJPOh0e2ZpMFqjNca1wApS9lJb7E4MjwGIczgt9iuKd8PEm6Pfgp2bJ92Xtg=="
+			"version": "0.156.1",
+			"resolved": "https://registry.npmjs.org/three/-/three-0.156.1.tgz",
+			"integrity": "sha512-kP7H0FK9d/k6t/XvQ9FO6i+QrePoDcNhwl0I02+wmUJRNSLCUIDMcfObnzQvxb37/0Uc9TDT0T1HgsRRrO6SYQ=="
 		},
 		"through": {
 			"version": "2.3.8",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "skinview3d",
-	"version": "3.0.0",
+	"version": "3.0.1",
 	"description": "Three.js powered Minecraft skin viewer",
 	"main": "libs/skinview3d.js",
 	"type": "module",
@@ -42,10 +42,9 @@
 	"dependencies": {
 		"@types/three": "^0.142.0",
 		"skinview-utils": "^0.7.1",
-		"three": "^0.142.0"
+		"three": "^0.156.1"
 	},
 	"devDependencies": {
-		"@gplane/tsconfig": "^6.0.0",
 		"@rollup/plugin-node-resolve": "^15.0.2",
 		"@swc/core": "^1.3.53",
 		"@typescript-eslint/eslint-plugin": "^5.59.0",

--- a/src/model.ts
+++ b/src/model.ts
@@ -39,18 +39,20 @@ function setUVs(
 	const uvAttr = box.attributes.uv as BufferAttribute;
 	const uvData = uvAttr.array;
 
-	const uvright = [right[3], right[2], right[0], right[1]];
-	const uvleft = [left[3], left[2], left[0], left[1]];
-	const uvtop = [top[3], top[2], top[0], top[1]];
-	const uvbottom = [bottom[0], bottom[1], bottom[3], bottom[2]];
-	const uvfront = [front[3], front[2], front[0], front[1]];
-	const uvback = [back[3], back[2], back[0], back[1]];
+	const uvRight = [right[3], right[2], right[0], right[1]];
+	const uvLeft = [left[3], left[2], left[0], left[1]];
+	const uvTop = [top[3], top[2], top[0], top[1]];
+	const uvBottom = [bottom[0], bottom[1], bottom[3], bottom[2]];
+	const uvFront = [front[3], front[2], front[0], front[1]];
+	const uvBack = [back[3], back[2], back[0], back[1]];
 
 	// Iterate over the arrays and copy the data to uvData
 	let index = 0;
-	for (const uvArray of [uvright, uvleft, uvtop, uvbottom, uvfront, uvback]) {
+	for (const uvArray of [uvRight, uvLeft, uvTop, uvBottom, uvFront, uvBack]) {
   	for (const uv of uvArray) {
+  		// @ts-ignore
     	uvData[index++] = uv.x;
+  		// @ts-ignore
     	uvData[index++] = uv.y;
   	}
 	}

--- a/src/model.ts
+++ b/src/model.ts
@@ -49,12 +49,12 @@ function setUVs(
 	// Iterate over the arrays and copy the data to uvData
 	let index = 0;
 	for (const uvArray of [uvRight, uvLeft, uvTop, uvBottom, uvFront, uvBack]) {
-  	for (const uv of uvArray) {
-  		// @ts-ignore
-    	uvData[index++] = uv.x;
-  		// @ts-ignore
-    	uvData[index++] = uv.y;
-  	}
+		for (const uv of uvArray) {
+			// @ts-ignore
+			uvData[index++] = uv.x;
+			// @ts-ignore
+			uvData[index++] = uv.y;
+		}
 	}
 	uvAttr.needsUpdate = true;
 }

--- a/src/model.ts
+++ b/src/model.ts
@@ -37,8 +37,6 @@ function setUVs(
 	const back = toFaceVertices(u + width + depth * 2, v + depth, u + width * 2 + depth * 2, v + height + depth);
 
 	const uvAttr = box.attributes.uv as BufferAttribute;
-	const uvData = uvAttr.array;
-
 	const uvRight = [right[3], right[2], right[0], right[1]];
 	const uvLeft = [left[3], left[2], left[0], left[1]];
 	const uvTop = [top[3], top[2], top[0], top[1]];
@@ -46,16 +44,17 @@ function setUVs(
 	const uvFront = [front[3], front[2], front[0], front[1]];
 	const uvBack = [back[3], back[2], back[0], back[1]];
 
+	// Create a new array to hold the modified UV data
+	const newUVData = [];
+
 	// Iterate over the arrays and copy the data to uvData
-	let index = 0;
 	for (const uvArray of [uvRight, uvLeft, uvTop, uvBottom, uvFront, uvBack]) {
 		for (const uv of uvArray) {
-			// @ts-ignore
-			uvData[index++] = uv.x;
-			// @ts-ignore
-			uvData[index++] = uv.y;
+			newUVData.push(uv.x, uv.y);
 		}
 	}
+
+	uvAttr.set(new Float32Array(newUVData));
 	uvAttr.needsUpdate = true;
 }
 

--- a/src/model.ts
+++ b/src/model.ts
@@ -37,32 +37,23 @@ function setUVs(
 	const back = toFaceVertices(u + width + depth * 2, v + depth, u + width * 2 + depth * 2, v + height + depth);
 
 	const uvAttr = box.attributes.uv as BufferAttribute;
-	uvAttr.copyVector2sArray([
-		right[3],
-		right[2],
-		right[0],
-		right[1],
-		left[3],
-		left[2],
-		left[0],
-		left[1],
-		top[3],
-		top[2],
-		top[0],
-		top[1],
-		bottom[0],
-		bottom[1],
-		bottom[3],
-		bottom[2],
-		front[3],
-		front[2],
-		front[0],
-		front[1],
-		back[3],
-		back[2],
-		back[0],
-		back[1],
-	]);
+	const uvData = uvAttr.array;
+
+	const uvright = [right[3], right[2], right[0], right[1]];
+	const uvleft = [left[3], left[2], left[0], left[1]];
+	const uvtop = [top[3], top[2], top[0], top[1]];
+	const uvbottom = [bottom[0], bottom[1], bottom[3], bottom[2]];
+	const uvfront = [front[3], front[2], front[0], front[1]];
+	const uvback = [back[3], back[2], back[0], back[1]];
+
+	// Iterate over the arrays and copy the data to uvData
+	let index = 0;
+	for (const uvArray of [uvright, uvleft, uvtop, uvbottom, uvfront, uvback]) {
+  	for (const uv of uvArray) {
+    	uvData[index++] = uv.x;
+    	uvData[index++] = uv.y;
+  	}
+	}
 	uvAttr.needsUpdate = true;
 }
 

--- a/src/viewer.ts
+++ b/src/viewer.ts
@@ -279,7 +279,7 @@ export class SkinViewer {
 	 */
 	readonly playerWrapper: Group;
 
-	readonly globalLight: AmbientLight = new AmbientLight(0xffffff, 0.4);
+	readonly globalLight: AmbientLight = new AmbientLight(0xffffff, 3);
 	readonly cameraLight: PointLight = new PointLight(0xffffff, 0.6);
 
 	readonly composer: EffectComposer;

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,9 +1,30 @@
 {
-	"extends": "@gplane/tsconfig",
 	"compilerOptions": {
-		"target": "es2019",
 		"outDir": "libs",
-		"noUncheckedIndexedAccess": false
+		"allowJs": false,
+		"allowSyntheticDefaultImports": true,
+		"allowUnreachableCode": false,
+		"allowUnusedLabels": false,
+		"alwaysStrict": true,
+		"declaration": true,
+		"esModuleInterop": true,
+		"verbatimModuleSyntax": true,
+		"isolatedModules": true,
+		"module": "nodenext",
+		"moduleResolution": "nodenext",
+		"newLine": "LF",
+		"noEmitOnError": true,
+		"noUncheckedIndexedAccess": false,
+		"noUnusedLocals": true,
+		"noUnusedParameters": true,
+		"pretty": true,
+		"resolveJsonModule": true,
+		"skipLibCheck": true,
+		"sourceMap": true,
+		"strict": true,
+		"stripInternal": true,
+		"target": "es2021",
+		"useDefineForClassFields": true
 	},
 	"include": ["src"]
 }


### PR DESCRIPTION
Fix #144

- Update three.js to version `0.156.1`
- Refactor the uv copy logic as `copyVector2sArray` was removed
- Change the ambient light from `0.4` -> `3` (not sure why we have to do this)
- Remove `@gplane/tsconfig` as it doesn't allow us to make direct changes to it