### PR TITLE
chore: link to new minecraft.wiki rather than fandom wiki (fewer ads)

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,7 +96,7 @@ will completely disable shadows.
 ## Ears
 skinview3d supports two types of ear texture:
 * `standalone`: 14x7 image that contains the ear ([example](https://github.com/bs-community/skinview3d/blob/master/examples/img/ears.png))
-* `skin`: Skin texture that contains the ear (e.g. [deadmau5's skin](https://minecraft.fandom.com/wiki/Easter_eggs#Deadmau5.27s_ears))
+* `skin`: Skin texture that contains the ear (e.g. [deadmau5's skin](https://minecraft.wiki/w/Easter_eggs#deadmau5's_ears))
 
 Usage:
 ```js


### PR DESCRIPTION
This PR changes a URL in the docs from `minecraft.fandom.com` to `minecraft.wiki`. The latter has fewer ads, faster load times and is generally the more popular wiki with the community

thanks!